### PR TITLE
Fix #30 by disallowing MCP v2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.6.0,<2.0",
     "arxiv-to-prompt>=0.10.0",
 ]
 


### PR DESCRIPTION
Fixes #30 by disallowing in pyproject.toml. Can be reverted later if code is changed to support MCP v2.0.